### PR TITLE
Add Payment Tests and Supporting Utilities

### DIFF
--- a/src/main/kotlin/framework/pages/ConfirmPaymentPage.kt
+++ b/src/main/kotlin/framework/pages/ConfirmPaymentPage.kt
@@ -1,0 +1,41 @@
+package framework.pages
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+
+class ConfirmPaymentPage(private val driver: WebDriver) {
+
+    private val paymentCodeInput: By = By.id("code")
+    private val submitButton: By = By.cssSelector("button[type='submit']")
+    private val successBlock: By = By.className("success-container")
+    private val failBlock: By = By.className("fail-container")
+
+    fun openConfirmPage(uri: String, operationId: String) {
+        driver.get("$uri?operationId=$operationId")
+    }
+
+    fun enterPaymentCode(code: String) {
+        driver.findElement(paymentCodeInput).sendKeys(code)
+    }
+
+    fun submitPayment() {
+        driver.findElement(submitButton).click()
+    }
+
+    fun getSuccessMessage(): String {
+        return getMessageFromBlock(successBlock)
+    }
+
+    fun getFailureMessage(): String {
+        return getMessageFromBlock(failBlock)
+    }
+
+    private fun getMessageFromBlock(blockLocator: By): String {
+        val wait = WebDriverWait(driver, 10)
+        val blockElement: WebElement = wait.until(ExpectedConditions.visibilityOfElementLocated(blockLocator))
+        return blockElement.findElement(By.cssSelector("p")).text
+    }
+}

--- a/src/main/kotlin/utils/AuthUtils.kt
+++ b/src/main/kotlin/utils/AuthUtils.kt
@@ -1,0 +1,14 @@
+package utils
+
+import java.util.Base64
+
+object AuthUtils {
+    private const val MID = "4327306933PP"
+    private const val MKEY = "fhzdkytO}8nGw23"
+
+    fun getAuthHeader(): String {
+        val credentials = "$MID:$MKEY"
+        val encoded = Base64.getEncoder().encodeToString(credentials.toByteArray())
+        return "Basic $encoded"
+    }
+}

--- a/src/main/kotlin/utils/DataUtils.kt
+++ b/src/main/kotlin/utils/DataUtils.kt
@@ -1,0 +1,27 @@
+package utils
+
+import java.math.BigDecimal
+import kotlin.random.Random
+
+object DataUtils {
+
+    fun generateRandomName(): String {
+        val chars = ('A'..'Z') + ('a'..'z')
+        val length = Random.nextInt(4, 21)
+        return (1..length)
+            .map { chars.random() }
+            .joinToString("")
+            .replaceFirstChar { it.uppercase() }
+    }
+
+    fun generateRandomPhone(): String {
+        return (99000000..99999999).random().toString()
+    }
+
+    fun generateRandomAmount(): String {
+        val amount = Random.nextInt(10_00, 1000_00 + 1)
+        return BigDecimal(amount)
+            .divide(BigDecimal(100))
+            .toString()
+    }
+}

--- a/src/test/kotlin/PaymentTests.kt
+++ b/src/test/kotlin/PaymentTests.kt
@@ -1,0 +1,152 @@
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import framework.webDriver
+import helpers.httpClient
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.client.methods.HttpPost
+import org.apache.http.entity.StringEntity
+import org.apache.http.util.EntityUtils
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.openqa.selenium.By
+import org.openqa.selenium.support.ui.ExpectedConditions
+import org.openqa.selenium.support.ui.WebDriverWait
+import utils.AuthUtils
+import utils.DataUtils
+import utils.wait
+
+class PaymentTests {
+    private val createUrl = "https://test-app-ext.2ip.in/api/payment/create"
+    private val statusUrl = "https://test-app-ext.2ip.in/api/payment/status/%s"
+
+    private val objectMapper = ObjectMapper()
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun tearDown(): Unit {
+            webDriver.quit()
+        }
+    }
+
+    @Test
+    fun `test payment done status`() {
+        val (uri, operationId) = createPayment()
+
+        checkPaymentStatusWithRetries(operationId, "created")
+
+        confirmPayment(uri, operationId, false)
+
+        checkPaymentStatusWithRetries(operationId, "done")
+    }
+
+    @Test
+    fun `test payment rejected status`() {
+        val (uri, operationId) = createPayment()
+
+        checkPaymentStatusWithRetries(operationId, "created")
+
+        confirmPayment(uri, operationId, true)
+
+        checkPaymentStatusWithRetries(operationId, "rejected")
+    }
+
+    private fun createPayment(): Pair<String, String> {
+        val createRequest = HttpPost(createUrl)
+
+        createRequest.addHeader("Authorization", AuthUtils.getAuthHeader())
+        createRequest.addHeader("Content-Type", "application/json")
+
+        val name = DataUtils.generateRandomName()
+        val phone = DataUtils.generateRandomPhone()
+        val amount = DataUtils.generateRandomAmount()
+
+        val requestBody = """
+        {
+          "endUser": {
+            "fullName": "%s",
+            "phone": "%s"
+          },
+          "order": {
+            "amount": {
+              "currency": "USD",
+              "value": "%s"
+            }
+          }
+        }
+    """.trimIndent().format(name, phone, amount)
+
+        createRequest.entity = StringEntity(requestBody)
+
+        val createResponse = httpClient.execute(createRequest)
+        val createResponseBody = EntityUtils.toString(createResponse.entity)
+
+        assertEquals(200, createResponse.statusLine.statusCode)
+        assertTrue(createResponseBody.contains("\"status\":\"success\""))
+        assertTrue(createResponseBody.contains("\"status\":\"created\""))
+
+        val jsonNode: JsonNode = objectMapper.readTree(createResponseBody)
+        val uri = jsonNode["result"]["location"]["uri"].asText()
+        val operationId = jsonNode["result"]["operation"]["id"].asText()
+
+        return Pair(uri, operationId)
+    }
+
+    private fun confirmPayment(uri: String, operationId: String, isRejected: Boolean) {
+        //todo post?
+        webDriver.get("$uri?operationId=$operationId")
+
+        val paymentCode = if (isRejected) 1231 else 1234
+        val paymentCodeInput = webDriver.findElement(By.id("code"))
+        paymentCodeInput.sendKeys(paymentCode.toString())
+
+        val submitButton = webDriver.findElement(By.cssSelector("button[type='submit']"))
+        submitButton.click()
+
+        val successBlockLocator = By.className("success-container")
+
+        val wait = WebDriverWait(webDriver, 10)
+        val successBlock = wait.until(ExpectedConditions.visibilityOfElementLocated(successBlockLocator))
+
+        val successBlockTitle = successBlock.findElement(By.cssSelector("h1")).text
+        val successBlockText = successBlock.findElement(By.cssSelector("p")).text
+
+        assertEquals("Success!", successBlockTitle, "Expected success message not found")
+        assertTrue(
+            successBlockText.contains("Operation $operationId was accepted"),
+            "Operation ID in success message is incorrect"
+        )
+    }
+
+    private fun checkPaymentStatusWithRetries(operationId: String, expectedStatus: String, maxRetries: Int = 14) {
+        val statusRequest = HttpGet(statusUrl.format(operationId))
+
+        var attempts = 0
+        while (attempts < maxRetries) {
+
+            val statusResponse = httpClient.execute(statusRequest)
+            val statusResponseBody = EntityUtils.toString(statusResponse.entity)
+
+            assertEquals(200, statusResponse.statusLine.statusCode)
+
+            val jsonNode: JsonNode = objectMapper.readTree(statusResponseBody)
+            when (val operationStatus = jsonNode["result"]["operation"]["status"].asText()) {
+                expectedStatus -> {
+                    return
+                }
+
+                "processing" -> {
+                    attempts++
+                    wait(1000)
+                }
+
+                else -> {
+                    throw AssertionError("Unexpected status '$operationStatus'.")
+                }
+            }
+        }
+        throw AssertionError("Max retries reached. Status did not change to '$expectedStatus'.")
+    }
+}


### PR DESCRIPTION
This PR adds:

- `PaymentTests` covering success, rejection, already processed, and nonexistent payment scenarios.
- `ConfirmPaymentPage` to encapsulate UI interactions for payment confirmation.
- Utility classes:
   - `AuthUtils` for authorization headers.
   - `DataUtils` for generating random test data.